### PR TITLE
chore: updating pre-commit-hooks version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v5.0.0
     hooks:
     - id: check-added-large-files
     - id: check-toml


### PR DESCRIPTION
## What does this PR do?
- Updates the version of the `pre-commit-hooks` hook

## Why is this change happening?
To keep the pre-commit hook up to date

## How was this tested?
Ran pre-commit hook locally

## Checklist before merging:
- [x] Code follows project coding standards.
- [x] Tests pass locally.
- [x] Documentation has been updated (if necessary).
- [x] Relevant issues or tasks are linked.
